### PR TITLE
Added option to use global-mode-string

### DIFF
--- a/cpu-stats.el
+++ b/cpu-stats.el
@@ -51,6 +51,7 @@
 (defvar cpu-usage-timer nil)
 (defvar cpu-usage-mode-line-string "")
 (defvar cpu-usage-formatters nil)
+(defvar cpu-usage-use-global-mode-string t)
 
 (defgroup cpu-usage nil
   "Display various CPU stats in the mode-line."
@@ -74,7 +75,8 @@
 (defun cpu-usage-start ()
   "Start displaying CPU usage stats in the mode-line."
   (interactive)
-  (add-to-list 'global-mode-string 'cpu-usage-mode-line-string t)
+  (when cpu-usage-use-global-mode-string
+    (add-to-list 'global-mode-string 'cpu-usage-mode-line-string t))
   (and cpu-usage-timer (cancel-timer cpu-usage-timer))
   (setq cpu-usage-mode-line-string "")
   (setq *previous-stats* (read-stats))
@@ -89,8 +91,9 @@
   "Stop displaying CPU usage stats in the mode-line."
   (interactive)
   (setq cpu-usage-mode-line-string "")
-  (setq global-mode-string (delq 'cpu-usage-mode-line-string
-                                 global-mode-string))
+  (when cpu-usage-use-global-mode-string
+    (setq global-mode-string (delq 'cpu-usage-mode-line-string
+                                   global-mode-string)))
   (setq cpu-usage-timer
         (and cpu-usage-timer (cancel-timer cpu-usage-timer))))
 

--- a/memory-stats.el
+++ b/memory-stats.el
@@ -58,6 +58,7 @@
 (defvar memory-usage-formatters nil)
 (defvar memory-usage-timer nil)
 (defvar memory-usage-mode-line-string "")
+(defvar memory-usage-use-global-mode-string t)
 
 (defgroup memory-usage nil
   "Display various memory stats in the mode-line."
@@ -89,7 +90,8 @@
 (defun memory-usage-start ()
   "Start displaying memory usage stats in the mode-line."
   (interactive)
-  (add-to-list 'global-mode-string 'memory-usage-mode-line-string t)
+  (when memory-usage-use-global-mode-string
+    (add-to-list 'global-mode-string 'memory-usage-mode-line-string t))
   (and memory-usage-timer (cancel-timer memory-usage-timer))
   (setq memory-usage-mode-line-string "")
   (setq memory-usage-timer (run-at-time memory-usage-update-interval
@@ -103,8 +105,9 @@
   "Stop displaying memory usage stats in the mode-line."
   (interactive)
   (setq memory-usage-mode-line-string "")
-  (setq global-mode-string (delq 'memory-usage-mode-line-string
-                                 global-mode-string))
+  (when memory-usage-use-global-mode-string
+    (setq global-mode-string (delq 'memory-usage-mode-line-string
+                                   global-mode-string)))
   (setq memory-usage-timer
         (and memory-usage-timer (cancel-timer memory-usage-timer))))
 

--- a/misc-stats.el
+++ b/misc-stats.el
@@ -90,11 +90,13 @@
 (defvar misc-stats-mode-line-string "")
 (defvar misc-stats-timer nil)
 (defvar misc-stats-formatters nil)
+(defvar misc-stats-use-global-mode-string t)
 
 (defun misc-stats-start ()
   "Start displaying misc stats in the mode-line."
   (interactive)
-  (add-to-list 'global-mode-string 'misc-stats-mode-line-string t)
+  (when misc-stats-use-global-mode-string
+    (add-to-list 'global-mode-string 'misc-stats-mode-line-string t))
   (and misc-stats-timer (cancel-timer misc-stats-timer))
   (setq misc-stats-mode-line-string "")
   (setq misc-stats-timer (run-at-time misc-update-interval
@@ -108,8 +110,9 @@
   "Stop displaying misc system stats in the mode-line."
   (interactive)
   (setq misc-stats-mode-line-string "")
-  (setq global-mode-string (delq 'misc-stats-mode-line-string
-                                 global-mode-string))
+  (when misc-stats-use-global-mode-string
+    (setq global-mode-string (delq 'misc-stats-mode-line-string
+                                   global-mode-string)))
   (setq misc-stats-timer
         (and misc-stats-timer (cancel-timer misc-stats-timer))))
 


### PR DESCRIPTION
I've added an option to control the use of global-mode-string.

It's useful if you want to use it without relying in global-mode-string. This allows customizing like you did in gist https://gist.github.com/Idorobots/3866870 but still showing the global-mode-string in mode-line for the rest of modes
